### PR TITLE
Add self-service project submission workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ To run this portfolio locally, follow these steps:
 3. Start the development server with `npm run dev`.
 4. Open your browser and navigate to `http://localhost:3000`.
 
+#### Quick project submissions (no code editor required)
+
+1. Set the `PROJECT_SUBMISSION_TOKEN` environment variable locally (e.g. in a `.env.local` file) and on your hosting provider. This protects the submission form from public access.
+2. (Optional) To store projects in Supabase instead of the local JSON fallback, add the following environment variables:
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   
+   Create a `projects` table with the columns `id`, `name`, `description`, `remark`, `link` (text/varchar) and JSONB columns for `images`, `frameworks`, and `cloud`.
+3. Visit `/universe/planets/new` to open the submission dashboard. Fill out the form and provide the submission token when asked. Projects appear instantly after saving.
+
 ---
 
 ### Features

--- a/actions/projects.ts
+++ b/actions/projects.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type {
+  ProjectCloudProvider,
+  ProjectImage,
+  ProjectTechnology,
+} from "@/constants/type";
+import { saveProject } from "@/lib/projectStore";
+
+export interface ProjectActionResponse {
+  success: boolean;
+  message: string;
+}
+
+const parseJsonArray = <T>(
+  raw: FormDataEntryValue | null,
+  label: string
+): { value: T[]; error?: string } => {
+  if (!raw) {
+    return { value: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(String(raw));
+    if (!Array.isArray(parsed)) {
+      return { value: [], error: `${label} must be an array.` };
+    }
+
+    return { value: parsed as T[] };
+  } catch (error) {
+    return { value: [], error: `Unable to parse ${label}.` };
+  }
+};
+
+const normalizeText = (value: FormDataEntryValue | null) =>
+  typeof value === "string" ? value.trim() : "";
+
+const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const createProject = async (
+  formData: FormData
+): Promise<ProjectActionResponse> => {
+  const token = normalizeText(formData.get("token"));
+  if (!token || token !== process.env.PROJECT_SUBMISSION_TOKEN) {
+    return { success: false, message: "Invalid submission token." };
+  }
+
+  const id = normalizeText(formData.get("id"));
+  const name = normalizeText(formData.get("name"));
+  const description = normalizeText(formData.get("description"));
+  const remark = normalizeText(formData.get("remark"));
+  const link = normalizeText(formData.get("link"));
+
+  if (!id) {
+    return { success: false, message: "A project id (slug) is required." };
+  }
+
+  if (!slugRegex.test(id)) {
+    return {
+      success: false,
+      message:
+        "The project id must use lowercase letters, numbers, and hyphens only.",
+    };
+  }
+
+  if (!name) {
+    return { success: false, message: "A project name is required." };
+  }
+
+  if (!description) {
+    return { success: false, message: "Please provide a project description." };
+  }
+
+  const imagesResult = parseJsonArray<ProjectImage>(formData.get("images"), "images");
+  const frameworksResult = parseJsonArray<ProjectTechnology>(
+    formData.get("frameworks"),
+    "frameworks"
+  );
+  const cloudResult = parseJsonArray<ProjectCloudProvider>(
+    formData.get("cloud"),
+    "cloud providers"
+  );
+
+  if (imagesResult.error || frameworksResult.error || cloudResult.error) {
+    return {
+      success: false,
+      message:
+        imagesResult.error || frameworksResult.error || cloudResult.error ||
+        "The submitted project includes invalid JSON data.",
+    };
+  }
+
+  const result = await saveProject({
+    id,
+    name,
+    description,
+    remark,
+    link: link || undefined,
+    images: imagesResult.value,
+    frameworks: frameworksResult.value,
+    cloud: cloudResult.value,
+  });
+
+  if (!result.success) {
+    return {
+      success: false,
+      message: result.message ?? "Unable to save the project right now.",
+    };
+  }
+
+  revalidatePath("/universe/planets");
+  revalidatePath(`/universe/planets/${id}`);
+
+  return {
+    success: true,
+    message: "Project saved successfully!",
+  };
+};

--- a/app/universe/planets/[id]/page.tsx
+++ b/app/universe/planets/[id]/page.tsx
@@ -1,34 +1,38 @@
-import PlanetPreviewComponent from "@/components/sub/PlanetPreview";
-import { Planets } from "@/constants";
 import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import PlanetPreviewComponent from "@/components/sub/PlanetPreview";
+import { fetchProjectById } from "@/lib/projectStore";
 
-  export async function generateMetadata({
-    params,
-  }: {
-    params: { id: string };
-  }): Promise<Metadata> {
-    const { id } = params;
-    const planet: Planet = Planets.find((planet) => planet.id === id)!;
+interface Params {
+  params: { id: string };
+}
 
-    if (!planet) {
-      return {
-        title: "No Planet Found",
-        description: "The requested planet was destroyed by the Death Star",
-      };
-    }
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const project = await fetchProjectById(params.id);
 
+  if (!project) {
     return {
-      title: planet.name as string,
-      description: planet.name as string,
+      title: "Project not found",
+      description: "The project you are looking for does not exist.",
     };
   }
 
-export default function PlanetsPage({params}:{params:{id:string}}) {
-    const {id} = params;
-    const planet: Planet = Planets.find((planet) => planet.id === id)!;
-    return (
-      <div className="flex flex-col gap-20">
-        <PlanetPreviewComponent planet={planet} />
-      </div>
-    );
+  return {
+    title: project.name,
+    description: project.description,
+  };
+}
+
+export default async function PlanetsPage({ params }: Params) {
+  const project = await fetchProjectById(params.id);
+
+  if (!project) {
+    notFound();
   }
+
+  return (
+    <div className="flex flex-col gap-20">
+      <PlanetPreviewComponent planet={project} />
+    </div>
+  );
+}

--- a/app/universe/planets/new/page.tsx
+++ b/app/universe/planets/new/page.tsx
@@ -1,0 +1,48 @@
+import { Metadata } from "next";
+import ProjectSubmissionForm from "@/components/sub/ProjectSubmissionForm";
+
+export const metadata: Metadata = {
+  title: "Submit a project",
+  description: "Add a new project to the portfolio without editing code.",
+};
+
+export default function NewProjectPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black via-black to-gray-900 py-16">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-6">
+        <header className="space-y-4 text-center">
+          <h1 className="text-3xl font-bold text-white sm:text-4xl">
+            Add a new project
+          </h1>
+          <p className="mx-auto max-w-2xl text-sm text-gray-300 sm:text-base">
+            Use this form to publish a project instantly. The submission token ensures that only you
+            (or trusted collaborators) can add new work to your portfolio without opening your code
+            editor.
+          </p>
+        </header>
+
+        <div className="rounded-2xl border border-gray-800 bg-black/60 p-8 shadow-2xl">
+          <ProjectSubmissionForm />
+        </div>
+
+        <section className="rounded-2xl border border-orange-500/40 bg-orange-500/10 p-6 text-sm text-orange-100">
+          <h2 className="mb-2 text-base font-semibold uppercase tracking-wide">How it works</h2>
+          <ol className="list-decimal space-y-2 pl-4 text-orange-100/90">
+            <li>
+              Set the <code className="rounded bg-black/40 px-1 py-0.5">PROJECT_SUBMISSION_TOKEN</code> environment
+              variable on your hosting provider. This value protects the form from public use.
+            </li>
+            <li>
+              (Optional) Connect a Supabase project and create a <code>projects</code> table with JSONB columns for
+              <em>images</em>, <em>frameworks</em>, and <em>cloud</em>. Add the URL and keys to your environment to store
+              everything centrally.
+            </li>
+            <li>
+              Fill out the form and submit. The portfolio revalidates automatically so the new project appears right away.
+            </li>
+          </ol>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/universe/planets/page.tsx
+++ b/app/universe/planets/page.tsx
@@ -1,63 +1,60 @@
+import Link from "next/link";
 import ProjectCard from "@/components/sub/ProjectCard";
 import { PlanetTitleText } from "@/components/sub/SkillText";
-import { Metadata } from "next";
+import { fetchProjects } from "@/lib/projectStore";
 
-export const metadata: Metadata = {
-  title: "My Projects",
-  description: "List of projects by Haariharan Rajakumar",
-};
+const placeholderImage = "/project-placeholder.svg";
 
-export default function PlanetsPage() {
+export default async function PlanetsPage() {
+  const projects = await fetchProjects();
+
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="py-10 px-4 sm:py-16 sm:px-6 lg:py-20 lg:px-8">
-        <PlanetTitleText />
-        <div className="flex flex-wrap justify-center gap-8 md:gap-12 lg:gap-16 px-2 md:px-4 lg:px-8">
-          <ProjectCard
-            src="/worldExpo1.png"
-            title="World Expo 2025 Monitoring Dashboard"
-            description="A web app that provides monitoring of the World Expo 2025, including impressive statistics of their ads and social media presence."
-            link="planets/worldExpo-my"
-          />
-          <ProjectCard
-            src="/insuredSpeaks1.png"
-            title="InsuredSpeaks"
-            description="A web app that allows users to share their insurance experiences and read others' reviews."
-            link="planets/insuredspeaks"
-          />
-          <ProjectCard
-            src="/lifepath1.png"
-            title="LifePath - Educational consulting platform"
-            description="LifePath is an educational consulting platform that connects students with lifepath experts to guide them in their academic and career paths."
-            link="planets/lifepath"
-          />
-          <ProjectCard
-            src="/jp1.PNG"
-            title="Landing Page for Coconut Bussiness"
-            description="A sleek and responsive landing page designed for a coconut business."
-            link="planets/coconut-landing-page"
-          />
-          <ProjectCard
-            src="/maths-generator.jpeg"
-            title="Maths Question Generator"
-            description="A web app that generates math questions for students to practice"
-            link="planets/maths-generator"
-          />
-          <ProjectCard
-            src="/pystorm1.webp"
-            title="Pystorm SaaS App"
-            description="Pystorm is a SaaS app which offers a user-friendly platform tailored for small businesses to simplify data management and visualization."
-            link="planets/pystorm-saas"
-          />
-          <ProjectCard
-            src="/pystorm-dashboard3.jpeg"
-            title="Pystorm Dashboard"
-            description="A web app that supports multi-tenancy, allowing users to view embedded dashboards that was made to visualize organization data"
-            link="planets/pystorm-dashboard"
-          />
+        <div className="flex flex-col items-center gap-6 md:flex-row md:justify-between">
+          <PlanetTitleText />
+          <Link
+            href="/universe/planets/new"
+            className="inline-flex items-center gap-2 rounded-lg border border-orange-500/60 bg-orange-500/10 px-4 py-2 text-sm font-semibold text-orange-200 transition hover:bg-orange-500/20"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 5v14M5 12h14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Add project
+          </Link>
         </div>
+
+        {projects.length === 0 ? (
+          <div className="mt-16 rounded-2xl border border-gray-800 bg-black/60 p-10 text-center">
+            <p className="text-base text-gray-300">
+              No projects found yet. Use the “Add project” button to publish your first one instantly.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-10 flex flex-wrap justify-center gap-8 md:gap-12 lg:gap-16 px-2 md:px-4 lg:px-8">
+            {projects.map((project) => (
+              <ProjectCard
+                key={project.id}
+                src={project.images?.[0]?.src ?? placeholderImage}
+                title={project.name}
+                description={project.description}
+                link={`planets/${project.id}`}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
 }
-

--- a/components/sub/PlanetCarousel.tsx
+++ b/components/sub/PlanetCarousel.tsx
@@ -3,7 +3,11 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
-const PlanetCarousel = ({ images }: { images: Image[] }) => {
+const PlanetCarousel = ({ images }: { images: {
+  src: string;
+  width: number;
+  height: number;
+}[] }) => {
   const [current, setCurrent] = useState(0);
   const [loading, setLoading] = useState(true);
 
@@ -39,7 +43,7 @@ const PlanetCarousel = ({ images }: { images: Image[] }) => {
             {images.map((img, index) => (
               <Image
                 key={index}
-                src={img}
+                src={img.src}
                 alt={`Slide ${index}`}
                 className="w-full h-auto flex-shrink-0"
                 onLoad={() => setLoading(false)} 

--- a/components/sub/PlanetPreview.tsx
+++ b/components/sub/PlanetPreview.tsx
@@ -77,7 +77,7 @@ const PlanetPreviewComponent = ({ planet }: { planet: Planet }) => {
               <div className="border-b border-gray-700/50 px-6">
                 <Tab.List className="flex space-x-8 -mb-px">
                   <Tab
-                    className={({ selected }) =>
+                    className={({ selected }:any) =>
                       classNames(
                         selected
                           ? "border-orange-500 text-orange-400 bg-orange-500/10"
@@ -89,7 +89,7 @@ const PlanetPreviewComponent = ({ planet }: { planet: Planet }) => {
                     Frameworks
                   </Tab>
                   <Tab
-                    className={({ selected }) =>
+                    className={({ selected }:any) =>
                       classNames(
                         selected
                           ? "border-orange-500 text-orange-400 bg-orange-500/10"

--- a/components/sub/PlanetPreview.tsx
+++ b/components/sub/PlanetPreview.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { Fragment } from "react";
 import { Tab } from "@headlessui/react";
-import PlanetCarousel from "./PlanetCarousel";
 import Image from "next/image";
+import type { Planet } from "@/constants/type";
+import PlanetCarousel from "./PlanetCarousel";
 
 const PlanetPreviewComponent = ({ planet }: { planet: Planet }) => {
   function classNames(...classes: string[]) {

--- a/components/sub/ProjectSubmissionForm.tsx
+++ b/components/sub/ProjectSubmissionForm.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { createProject } from "@/actions/projects";
+import type {
+  ProjectCloudProvider,
+  ProjectImage,
+  ProjectTechnology,
+} from "@/constants/type";
+
+interface FormStatus {
+  type: "idle" | "success" | "error";
+  message: string;
+}
+
+const createEmptyImage = (): ProjectImage => ({ src: "", width: 100, height: 100 });
+const createEmptyTechnology = (): ProjectTechnology => ({
+  name: "",
+  Image: "",
+  width: 80,
+  height: 80,
+});
+const createEmptyCloud = (): ProjectCloudProvider => ({
+  name: "",
+  Image: "",
+  width: 80,
+  height: 80,
+});
+
+const removeEmptyItems = <T extends { [key: string]: unknown }>(items: T[]) =>
+  items.filter((item) => Object.values(item).some((value) => value !== ""));
+
+export const ProjectSubmissionForm = () => {
+  const [images, setImages] = useState<ProjectImage[]>([createEmptyImage()]);
+  const [frameworks, setFrameworks] = useState<ProjectTechnology[]>([
+    createEmptyTechnology(),
+  ]);
+  const [cloudProviders, setCloudProviders] = useState<ProjectCloudProvider[]>([
+    createEmptyCloud(),
+  ]);
+  const [status, setStatus] = useState<FormStatus>({ type: "idle", message: "" });
+  const [isPending, startTransition] = useTransition();
+
+  const handleImageChange = (
+    index: number,
+    key: keyof ProjectImage,
+    value: string
+  ) => {
+    setImages((current) =>
+      current.map((image, currentIndex) =>
+        currentIndex === index
+          ? { ...image, [key]: key === "src" ? value : Number(value) }
+          : image
+      )
+    );
+  };
+
+  const handleFrameworkChange = (
+    index: number,
+    key: keyof ProjectTechnology,
+    value: string
+  ) => {
+    setFrameworks((current) =>
+      current.map((item, currentIndex) =>
+        currentIndex === index
+          ? { ...item, [key]: key === "name" || key === "Image" ? value : Number(value) }
+          : item
+      )
+    );
+  };
+
+  const handleCloudChange = (
+    index: number,
+    key: keyof ProjectCloudProvider,
+    value: string
+  ) => {
+    setCloudProviders((current) =>
+      current.map((item, currentIndex) =>
+        currentIndex === index
+          ? { ...item, [key]: key === "name" || key === "Image" ? value : Number(value) }
+          : item
+      )
+    );
+  };
+
+  const addImage = () => setImages((current) => [...current, createEmptyImage()]);
+  const addFramework = () =>
+    setFrameworks((current) => [...current, createEmptyTechnology()]);
+  const addCloud = () =>
+    setCloudProviders((current) => [...current, createEmptyCloud()]);
+
+  const removeImage = (index: number) =>
+    setImages((current) => current.filter((_, currentIndex) => currentIndex !== index));
+  const removeFramework = (index: number) =>
+    setFrameworks((current) =>
+      current.filter((_, currentIndex) => currentIndex !== index)
+    );
+  const removeCloud = (index: number) =>
+    setCloudProviders((current) =>
+      current.filter((_, currentIndex) => currentIndex !== index)
+    );
+
+  const resetForm = () => {
+    setImages([createEmptyImage()]);
+    setFrameworks([createEmptyTechnology()]);
+    setCloudProviders([createEmptyCloud()]);
+  };
+
+  const hasImages = useMemo(
+    () => images.some((image) => image.src.trim().length > 0),
+    [images]
+  );
+
+  return (
+    <form
+      className="space-y-10"
+      action={(formData) => {
+        const preparedImages = removeEmptyItems(images);
+        const preparedFrameworks = removeEmptyItems(frameworks);
+        const preparedClouds = removeEmptyItems(cloudProviders);
+
+        formData.set("images", JSON.stringify(preparedImages));
+        formData.set("frameworks", JSON.stringify(preparedFrameworks));
+        formData.set("cloud", JSON.stringify(preparedClouds));
+
+        setStatus({ type: "idle", message: "" });
+        startTransition(async () => {
+          const response = await createProject(formData);
+          setStatus(response);
+          if (response.success) {
+            resetForm();
+            (document.getElementById("project-form") as HTMLFormElement | null)?.reset();
+          }
+        });
+      }}
+      id="project-form"
+    >
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-semibold text-gray-200" htmlFor="token">
+            Submission token
+          </label>
+          <input
+            required
+            name="token"
+            id="token"
+            type="password"
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+            placeholder="Enter the secret token"
+          />
+          <p className="text-xs text-gray-400">
+            Define <code>PROJECT_SUBMISSION_TOKEN</code> in your environment and use it here to protect the form.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-semibold text-gray-200" htmlFor="id">
+            Project ID (slug)
+          </label>
+          <input
+            required
+            name="id"
+            id="id"
+            type="text"
+            pattern="[a-z0-9-]+"
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+            placeholder="e.g. nextjs-portfolio"
+          />
+          <p className="text-xs text-gray-400">
+            Lowercase letters, numbers, and hyphens only. This becomes the URL path.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-semibold text-gray-200" htmlFor="name">
+            Project name
+          </label>
+          <input
+            required
+            name="name"
+            id="name"
+            type="text"
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+            placeholder="Enter the project title"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-semibold text-gray-200" htmlFor="link">
+            Live link (optional)
+          </label>
+          <input
+            name="link"
+            id="link"
+            type="url"
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+            placeholder="https://example.com"
+          />
+        </div>
+      </section>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-semibold text-gray-200" htmlFor="description">
+          Project description
+        </label>
+        <textarea
+          required
+          name="description"
+          id="description"
+          rows={4}
+          className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+          placeholder="Describe what the project does and why it matters."
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-semibold text-gray-200" htmlFor="remark">
+          Personal contribution (optional)
+        </label>
+        <textarea
+          name="remark"
+          id="remark"
+          rows={3}
+          className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+          placeholder="Share highlights such as your role, achievements, or results."
+        />
+      </div>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-100">Project images</h2>
+          <button
+            type="button"
+            className="rounded-lg border border-orange-600 px-3 py-1 text-sm font-medium text-orange-400 transition hover:bg-orange-600/10"
+            onClick={addImage}
+          >
+            Add image
+          </button>
+        </div>
+        <p className="text-xs text-gray-400">
+          Provide at least one image to feature the project. Images are displayed in the preview carousel.
+        </p>
+        <div className="space-y-4">
+          {images.map((image, index) => (
+            <div
+              key={`image-${index}`}
+              className="rounded-xl border border-gray-800 bg-gray-900/70 p-4 shadow-inner"
+            >
+              <div className="flex flex-col gap-4 md:flex-row">
+                <div className="flex-1 space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Image URL
+                  </label>
+                  <input
+                    required={!hasImages}
+                    value={image.src}
+                    onChange={(event) => handleImageChange(index, "src", event.target.value)}
+                    placeholder="https://"
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                  />
+                </div>
+                <div className="grid flex-shrink-0 grid-cols-2 gap-4 md:w-56">
+                  <div className="space-y-2">
+                    <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      Width
+                    </label>
+                    <input
+                      type="number"
+                      value={image.width}
+                      onChange={(event) => handleImageChange(index, "width", event.target.value)}
+                      className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      Height
+                    </label>
+                    <input
+                      type="number"
+                      value={image.height}
+                      onChange={(event) => handleImageChange(index, "height", event.target.value)}
+                      className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    />
+                  </div>
+                </div>
+              </div>
+              {images.length > 1 && (
+                <div className="mt-4 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => removeImage(index)}
+                    className="text-sm text-gray-400 underline-offset-4 transition hover:text-orange-400 hover:underline"
+                  >
+                    Remove image
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-100">Frameworks & libraries</h2>
+          <button
+            type="button"
+            className="rounded-lg border border-orange-600 px-3 py-1 text-sm font-medium text-orange-400 transition hover:bg-orange-600/10"
+            onClick={addFramework}
+          >
+            Add framework
+          </button>
+        </div>
+        <div className="space-y-4">
+          {frameworks.map((framework, index) => (
+            <div
+              key={`framework-${index}`}
+              className="rounded-xl border border-gray-800 bg-gray-900/70 p-4 shadow-inner"
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Name
+                  </label>
+                  <input
+                    value={framework.name}
+                    onChange={(event) =>
+                      handleFrameworkChange(index, "name", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    placeholder="Next.js"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Icon URL
+                  </label>
+                  <input
+                    value={framework.Image}
+                    onChange={(event) =>
+                      handleFrameworkChange(index, "Image", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    placeholder="/next.png"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Width
+                  </label>
+                  <input
+                    type="number"
+                    value={framework.width}
+                    onChange={(event) =>
+                      handleFrameworkChange(index, "width", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Height
+                  </label>
+                  <input
+                    type="number"
+                    value={framework.height}
+                    onChange={(event) =>
+                      handleFrameworkChange(index, "height", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                  />
+                </div>
+              </div>
+              {frameworks.length > 1 && (
+                <div className="mt-4 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => removeFramework(index)}
+                    className="text-sm text-gray-400 underline-offset-4 transition hover:text-orange-400 hover:underline"
+                  >
+                    Remove framework
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-100">Cloud & infrastructure</h2>
+          <button
+            type="button"
+            className="rounded-lg border border-orange-600 px-3 py-1 text-sm font-medium text-orange-400 transition hover:bg-orange-600/10"
+            onClick={addCloud}
+          >
+            Add provider
+          </button>
+        </div>
+        <div className="space-y-4">
+          {cloudProviders.map((provider, index) => (
+            <div
+              key={`cloud-${index}`}
+              className="rounded-xl border border-gray-800 bg-gray-900/70 p-4 shadow-inner"
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Name
+                  </label>
+                  <input
+                    value={provider.name}
+                    onChange={(event) =>
+                      handleCloudChange(index, "name", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    placeholder="Vercel"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Icon URL
+                  </label>
+                  <input
+                    value={provider.Image}
+                    onChange={(event) =>
+                      handleCloudChange(index, "Image", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                    placeholder="/vercel.svg"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Width
+                  </label>
+                  <input
+                    type="number"
+                    value={provider.width}
+                    onChange={(event) =>
+                      handleCloudChange(index, "width", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Height
+                  </label>
+                  <input
+                    type="number"
+                    value={provider.height}
+                    onChange={(event) =>
+                      handleCloudChange(index, "height", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
+                  />
+                </div>
+              </div>
+              {cloudProviders.length > 1 && (
+                <div className="mt-4 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => removeCloud(index)}
+                    className="text-sm text-gray-400 underline-offset-4 transition hover:text-orange-400 hover:underline"
+                  >
+                    Remove provider
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {status.message && (
+        <div
+          role="status"
+          className={`rounded-lg border px-4 py-3 text-sm font-medium ${
+            status.type === "success"
+              ? "border-emerald-600/40 bg-emerald-600/10 text-emerald-200"
+              : status.type === "error"
+              ? "border-red-600/40 bg-red-600/10 text-red-200"
+              : "border-gray-700 bg-gray-900 text-gray-300"
+          }`}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="reset"
+          className="rounded-lg border border-gray-700 px-4 py-2 text-sm font-medium text-gray-300 transition hover:bg-gray-800"
+          onClick={() => {
+            resetForm();
+            setStatus({ type: "idle", message: "" });
+          }}
+        >
+          Reset
+        </button>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-orange-500 to-orange-600 px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:from-orange-600 hover:to-orange-700 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isPending ? (
+            <span className="flex items-center gap-2">
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                />
+              </svg>
+              Saving...
+            </span>
+          ) : (
+            "Save project"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ProjectSubmissionForm;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,3 +1,5 @@
+import type { Planet } from "./type";
+
 export const Skill_data = [
   {
     skill_name: "Html 5",

--- a/constants/type.ts
+++ b/constants/type.ts
@@ -1,31 +1,32 @@
-interface Image {
-    src: string;
-    width: number;
-    height: number;
+export interface ProjectImage {
+  src: string;
+  width: number;
+  height: number;
 }
 
-interface Framework {
-    name: string;
-    Image: string;
-    width: number;
-    height: number;
+export interface ProjectTechnology {
+  name: string;
+  Image: string;
+  width: number;
+  height: number;
 }
 
-interface Cloud {
-    name: string;
-    Image: string;
-    width: number;
-    height: number;
+export interface ProjectCloudProvider {
+  name: string;
+  Image: string;
+  width: number;
+  height: number;
 }
 
-interface Planet {
-    id: string;
-    name: string;
-    link?: string;
-    description: string;
-    remark: string;
-    images: Image[];
-    frameworks: Framework[];
-    cloud: Cloud[];
+export interface Planet {
+  id: string;
+  name: string;
+  link?: string;
+  description: string;
+  remark: string;
+  images: ProjectImage[];
+  frameworks: ProjectTechnology[];
+  cloud: ProjectCloudProvider[];
 }
 
+export type Project = Planet;

--- a/lib/projectStore.ts
+++ b/lib/projectStore.ts
@@ -1,0 +1,172 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { Planets } from "@/constants";
+import type {
+  Planet,
+  Project,
+  ProjectCloudProvider,
+  ProjectImage,
+  ProjectTechnology,
+} from "@/constants/type";
+import { promises as fs } from "fs";
+import path from "path";
+
+const dataDir = path.join(process.cwd(), "data");
+const projectsFilePath = path.join(dataDir, "projects.json");
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+interface SupabaseProjectRow {
+  id: string;
+  name: string;
+  link: string | null;
+  remark: string | null;
+  description: string;
+  images: ProjectImage[] | null;
+  frameworks: ProjectTechnology[] | null;
+  cloud: ProjectCloudProvider[] | null;
+  created_at?: string;
+}
+
+const hasSupabaseReadConfig = Boolean(supabaseUrl && supabaseAnonKey);
+const hasSupabaseWriteConfig = Boolean(supabaseUrl && supabaseServiceRoleKey);
+
+const toProject = (row: SupabaseProjectRow): Planet => ({
+  id: row.id,
+  name: row.name,
+  link: row.link ?? undefined,
+  remark: row.remark ?? "",
+  description: row.description,
+  images: Array.isArray(row.images) ? row.images : [],
+  frameworks: Array.isArray(row.frameworks) ? row.frameworks : [],
+  cloud: Array.isArray(row.cloud) ? row.cloud : [],
+});
+
+const mergeProjects = (base: Planet[], overrides: Planet[]): Planet[] => {
+  const map = new Map<string, Planet>();
+  base.forEach((project) => map.set(project.id, project));
+  overrides.forEach((project) => {
+    const existing = map.get(project.id);
+    map.set(project.id, existing ? { ...existing, ...project } : project);
+  });
+  return Array.from(map.values());
+};
+
+const ensureDataDirectory = async () => {
+  await fs.mkdir(dataDir, { recursive: true });
+};
+
+const readLocalProjects = async (): Promise<Planet[]> => {
+  try {
+    const file = await fs.readFile(projectsFilePath, "utf8");
+    const data = JSON.parse(file) as Planet[];
+    return mergeProjects(Planets, data);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return Planets;
+    }
+    console.error("Failed to read local projects store", error);
+    return Planets;
+  }
+};
+
+const writeLocalProjects = async (projects: Planet[]) => {
+  await ensureDataDirectory();
+  await fs.writeFile(projectsFilePath, JSON.stringify(projects, null, 2), "utf8");
+};
+
+const getSupabaseReadClient = (): SupabaseClient | null => {
+  if (!hasSupabaseReadConfig) {
+    return null;
+  }
+
+  return createClient(supabaseUrl as string, supabaseAnonKey as string, {
+    auth: { persistSession: false },
+  });
+};
+
+const getSupabaseWriteClient = (): SupabaseClient | null => {
+  if (!hasSupabaseWriteConfig) {
+    return null;
+  }
+
+  return createClient(supabaseUrl as string, supabaseServiceRoleKey as string, {
+    auth: { persistSession: false },
+  });
+};
+
+export const fetchProjects = async (): Promise<Planet[]> => {
+  const supabase = getSupabaseReadClient();
+
+  if (!supabase) {
+    return readLocalProjects();
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("projects")
+      .select("id, name, link, remark, description, images, frameworks, cloud")
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.warn("Falling back to local projects due to Supabase error", error);
+      return readLocalProjects();
+    }
+
+    if (!data || data.length === 0) {
+      return Planets;
+    }
+
+    const projects = data.map(toProject);
+    return mergeProjects(Planets, projects);
+  } catch (error) {
+    console.warn("Falling back to local projects due to Supabase failure", error);
+    return readLocalProjects();
+  }
+};
+
+export const fetchProjectById = async (id: string): Promise<Planet | null> => {
+  const projects = await fetchProjects();
+  return projects.find((project) => project.id === id) ?? null;
+};
+
+export const saveProject = async (
+  project: Project
+): Promise<{ success: boolean; message?: string }> => {
+  if (!project.id) {
+    return { success: false, message: "Project is missing an id." };
+  }
+
+  const supabase = getSupabaseWriteClient();
+  if (supabase) {
+    const { error } = await supabase.from("projects").upsert({
+      id: project.id,
+      name: project.name,
+      link: project.link ?? null,
+      remark: project.remark,
+      description: project.description,
+      images: project.images,
+      frameworks: project.frameworks,
+      cloud: project.cloud,
+    });
+
+    if (error) {
+      console.error("Failed to save project in Supabase", error);
+      return { success: false, message: error.message };
+    }
+
+    return { success: true };
+  }
+
+  const existing = await readLocalProjects();
+  const merged = mergeProjects(existing, [project]);
+
+  try {
+    await writeLocalProjects(merged);
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to save project locally", error);
+    return { success: false, message: "Unable to write project to local store." };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.7.19",
         "@heroicons/react": "^2.0.18",
+        "@supabase/supabase-js": "^2.58.0",
         "clsx": "^2.1.0",
         "framer-motion": "^10.18.0",
         "next": "^14.2.3",
@@ -716,6 +717,80 @@
       "integrity": "sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==",
       "dev": true
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -781,7 +856,6 @@
       "version": "20.11.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.4.tgz",
       "integrity": "sha512-6I0fMH8Aoy2lOejL3s4LhyIYX34DPwY8bl5xlNjBvUEk8OHrcuzsFt+Ied4LvJihbtXPM+8zUqdydfIti86v9g==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -791,6 +865,12 @@
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "dev": true
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -853,6 +933,15 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.10.tgz",
       "integrity": "sha512-n3u5sqXQJhf1CS68mw3Wf16FQ4cRPNBBwdYLFzq3UddiADOim1Pn3Y6PBdDilz1vOJF3ybLxJ8ZEDlLIzrOQZg==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.19.0",
@@ -5100,6 +5189,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/troika-three-text": {
       "version": "0.47.2",
       "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.2.tgz",
@@ -5322,8 +5417,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -5412,6 +5506,22 @@
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5603,6 +5713,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -6097,6 +6228,70 @@
       "integrity": "sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==",
       "dev": true
     },
+    "@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "requires": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -6149,7 +6344,6 @@
       "version": "20.11.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.4.tgz",
       "integrity": "sha512-6I0fMH8Aoy2lOejL3s4LhyIYX34DPwY8bl5xlNjBvUEk8OHrcuzsFt+Ied4LvJihbtXPM+8zUqdydfIti86v9g==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -6159,6 +6353,11 @@
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "dev": true
+    },
+    "@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
     },
     "@types/prop-types": {
       "version": "15.7.11",
@@ -6217,6 +6416,14 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.10.tgz",
       "integrity": "sha512-n3u5sqXQJhf1CS68mw3Wf16FQ4cRPNBBwdYLFzq3UddiADOim1Pn3Y6PBdDilz1vOJF3ybLxJ8ZEDlLIzrOQZg==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/parser": {
       "version": "6.19.0",
@@ -9212,6 +9419,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "troika-three-text": {
       "version": "0.47.2",
       "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.2.tgz",
@@ -9370,8 +9582,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",
@@ -9428,6 +9639,20 @@
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -9565,6 +9790,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "requires": {}
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.0.18",
+    "@supabase/supabase-js": "^2.58.0",
     "clsx": "^2.1.0",
     "framer-motion": "^10.18.0",
     "next": "^14.2.3",

--- a/public/project-placeholder.svg
+++ b/public/project-placeholder.svg
@@ -1,0 +1,24 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_1_1)"/>
+  <rect x="32" y="32" width="576" height="296" rx="18" fill="rgba(17, 24, 39, 0.65)" stroke="rgba(255, 255, 255, 0.08)" stroke-width="2"/>
+  <g filter="url(#filter0_d_1_1)">
+    <circle cx="320" cy="180" r="74" fill="rgba(252, 211, 77, 0.12)"/>
+  </g>
+  <circle cx="320" cy="180" r="48" fill="rgba(253, 186, 116, 0.15)" stroke="rgba(253, 186, 116, 0.6)" stroke-width="2"/>
+  <path d="M320 152L336 188H304L320 152Z" fill="rgba(253, 186, 116, 0.8)"/>
+  <path d="M320 210C324.418 210 328 206.418 328 202C328 197.582 324.418 194 320 194C315.582 194 312 197.582 312 202C312 206.418 315.582 210 320 210Z" fill="rgba(253, 186, 116, 0.8)"/>
+  <text x="50%" y="310" text-anchor="middle" fill="rgba(229, 231, 235, 0.7)" font-size="20" font-family="'Inter', sans-serif">
+    Preview coming soon
+  </text>
+  <defs>
+    <filter id="filter0_d_1_1" x="226" y="86" width="188" height="188" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="10" result="effect1_foregroundBlur_1_1"/>
+    </filter>
+    <linearGradient id="paint0_linear_1_1" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add a project data store that supports Supabase or a local JSON fallback and includes a placeholder image
- create an authenticated submission form at `/universe/planets/new` so projects can be added without editing code
- load project listings and detail pages from the shared store and document the new setup requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d62acfb03c833391d319fedfc7950d